### PR TITLE
feat: 일기장 관련 엔티티 구현

### DIFF
--- a/src/main/kotlin/taehyeon/brothers/writeln_backend/application/DiaryService.kt
+++ b/src/main/kotlin/taehyeon/brothers/writeln_backend/application/DiaryService.kt
@@ -1,0 +1,6 @@
+package taehyeon.brothers.writeln_backend.application
+
+import org.springframework.stereotype.Service
+
+@Service
+class DiaryService

--- a/src/main/kotlin/taehyeon/brothers/writeln_backend/application/TagService.kt
+++ b/src/main/kotlin/taehyeon/brothers/writeln_backend/application/TagService.kt
@@ -1,0 +1,7 @@
+package taehyeon.brothers.writeln_backend.application
+
+import org.springframework.stereotype.Service
+
+@Service
+class TagService {
+}

--- a/src/main/kotlin/taehyeon/brothers/writeln_backend/domain/Diary.kt
+++ b/src/main/kotlin/taehyeon/brothers/writeln_backend/domain/Diary.kt
@@ -10,8 +10,9 @@ class Diary(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0,
 
-    @Column(name = "user_id", nullable = false)
-    var userId: Long,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    var user: User,
 
     @Column(name = "title", length = 100, nullable = false)
     var title: String,

--- a/src/main/kotlin/taehyeon/brothers/writeln_backend/domain/Diary.kt
+++ b/src/main/kotlin/taehyeon/brothers/writeln_backend/domain/Diary.kt
@@ -16,6 +16,6 @@ class Diary(
     @Column(name = "title", length = 100, nullable = false)
     var title: String,
 
-    @Column(name = "content", length = 4000)
+    @Column(name = "content", length = 4000, nullable = false)
     var content: String
 )

--- a/src/main/kotlin/taehyeon/brothers/writeln_backend/domain/Diary.kt
+++ b/src/main/kotlin/taehyeon/brothers/writeln_backend/domain/Diary.kt
@@ -1,0 +1,21 @@
+package taehyeon.brothers.writeln_backend.domain
+
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "diaries")
+class Diary(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @Column(name = "user_id", nullable = false)
+    var userId: Long,
+
+    @Column(name = "title", length = 100, nullable = false)
+    var title: String,
+
+    @Column(name = "content", length = 4000)
+    var content: String
+)

--- a/src/main/kotlin/taehyeon/brothers/writeln_backend/domain/Tag.kt
+++ b/src/main/kotlin/taehyeon/brothers/writeln_backend/domain/Tag.kt
@@ -10,8 +10,9 @@ class Tag(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0,
 
-    @Column(name = "diary_id")
-    var diaryId: Long = 0,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "diary_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    var diary: Diary,
 
     @Column(name = "name", length = 100)
     var name: String

--- a/src/main/kotlin/taehyeon/brothers/writeln_backend/domain/Tag.kt
+++ b/src/main/kotlin/taehyeon/brothers/writeln_backend/domain/Tag.kt
@@ -1,0 +1,18 @@
+package taehyeon.brothers.writeln_backend.domain
+
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "tags")
+class Tag(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @Column(name = "diary_id")
+    var diaryId: Long = 0,
+
+    @Column(name = "content", length = 100)
+    var content: String
+)

--- a/src/main/kotlin/taehyeon/brothers/writeln_backend/domain/Tag.kt
+++ b/src/main/kotlin/taehyeon/brothers/writeln_backend/domain/Tag.kt
@@ -13,6 +13,6 @@ class Tag(
     @Column(name = "diary_id")
     var diaryId: Long = 0,
 
-    @Column(name = "content", length = 100)
-    var content: String
+    @Column(name = "name", length = 100)
+    var name: String
 )

--- a/src/main/kotlin/taehyeon/brothers/writeln_backend/infrastructure/DiaryRepository.kt
+++ b/src/main/kotlin/taehyeon/brothers/writeln_backend/infrastructure/DiaryRepository.kt
@@ -1,0 +1,6 @@
+package taehyeon.brothers.writeln_backend.infrastructure
+
+import org.springframework.data.jpa.repository.JpaRepository
+import taehyeon.brothers.writeln_backend.domain.Diary
+
+interface DiaryRepository : JpaRepository<Diary, Long>

--- a/src/main/kotlin/taehyeon/brothers/writeln_backend/presentation/controller/DiaryController.kt
+++ b/src/main/kotlin/taehyeon/brothers/writeln_backend/presentation/controller/DiaryController.kt
@@ -1,0 +1,6 @@
+package taehyeon.brothers.writeln_backend.presentation.controller
+
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class DiaryController


### PR DESCRIPTION
## 개요
- 일기장 관련 엔티티를 구현했습니다. 그 외 계층은 껍데기만 구현했어요.
- 일기장에는 여러 태그가 붙을 수 있고, 하나의 태그는 여러 일기장에 들어갈 수 있을 것 같은데요. 그래서 N:M 구조일 것 같아요. 양방향 vs 단방향 고민했다가 일단 단방향으로만 구현했습니다.

## 메인 리뷰어 지정 및 Due Date
- 메인 리뷰어 : @pjy1368  , Due Date : 2024-09-25(수) (급하진 않다고 생각함)

## 리뷰 시 참고 사항
- 리뷰어에게 의견이 필요하거나, 리뷰어가 중점적으로 보면 좋을 부분을 나열해주세요.
    - Diary-Tag 간 관계

## TODO
- 테스트 코드 (필수적)

## References
없음.

## 체크리스트
- [x] PR 제목을 명령형으로 작성했습니다.
- [x] 리뷰 리퀘스트 전에 셀프 리뷰를 진행했습니다.
- [x] 변경사항에 대한 테스트코드를 추가했습니다. 또는, 테스트코드가 필요없는 이유가 있습니다. **(별도 서브모듈에 User 테스트코드 구현되면 따르겠습니다.)** 