### PR TITLE
feat: 타임존 세팅 및 커스터마이징 기능 추가

### DIFF
--- a/src/main/kotlin/taehyeon/brothers/matchreal/application/daily/service/DailyService.kt
+++ b/src/main/kotlin/taehyeon/brothers/matchreal/application/daily/service/DailyService.kt
@@ -9,6 +9,7 @@ import taehyeon.brothers.matchreal.domain.daily.Daily
 import taehyeon.brothers.matchreal.domain.user.User
 import taehyeon.brothers.matchreal.exception.business.DailyUploadTimeException
 import taehyeon.brothers.matchreal.exception.business.NotFoundImageException
+import taehyeon.brothers.matchreal.infrastructure.common.LocalDateTimeHelper
 import taehyeon.brothers.matchreal.infrastructure.daily.repository.DailyRepository
 
 @Service
@@ -28,7 +29,7 @@ class DailyService(
     }
 
     private fun validateUploadTime() {
-        val now = LocalTime.now()
+        val now = LocalDateTimeHelper.now().toLocalTime()
         val start = LocalTime.of(13, 0)
         val end = LocalTime.of(19, 0)
 

--- a/src/main/kotlin/taehyeon/brothers/matchreal/infrastructure/common/LocalDateTimeHelper.kt
+++ b/src/main/kotlin/taehyeon/brothers/matchreal/infrastructure/common/LocalDateTimeHelper.kt
@@ -1,0 +1,39 @@
+package taehyeon.brothers.matchreal.infrastructure.common
+
+import java.time.Clock
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+class LocalDateTimeHelper {
+
+    companion object {
+
+        private var clock = Clock.system(zoneId())
+
+        /**
+         * 해당 now 를 사용하면, 우리가 시스템 시각을 커스터마이징 가능하다.
+         */
+        fun now(): LocalDateTime {
+            return LocalDateTime.now(clock)
+        }
+
+        /**
+         * 시스템 시각을 특정 시각으로 변경하여 고정한다.
+         * 해당 함수를 사용한 뒤에는 반드시 unfixCurrentTime 를 사용하여 원래의 system time 으로 변경해야 한다.
+         * @see unfixCurrentTime
+         */
+        fun fixCurrentTime(localDateTime: LocalDateTime) {
+            clock = Clock.fixed(ZonedDateTime.of(localDateTime, zoneId()).toInstant(), zoneId())
+        }
+
+        /**
+         * 시스템 시각을 한국 기본값 (UTC+9) 로 세팅 원복한다.
+         */
+        fun unfixCurrentTime() {
+            clock = Clock.system(zoneId())
+        }
+
+        private fun zoneId(): ZoneId = ZoneId.of("Asia/Seoul")
+    }
+}

--- a/src/main/kotlin/taehyeon/brothers/matchreal/infrastructure/config/TimeConfig.kt
+++ b/src/main/kotlin/taehyeon/brothers/matchreal/infrastructure/config/TimeConfig.kt
@@ -1,0 +1,14 @@
+package taehyeon.brothers.matchreal.infrastructure.config
+
+import jakarta.annotation.PostConstruct
+import java.util.*
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class TimeConfig {
+
+    @PostConstruct
+    fun timeConfig() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"))
+    }
+}

--- a/src/test/kotlin/taehyeon/brothers/matchreal/infrastructure/common/LocalDateTimeHelperTest.kt
+++ b/src/test/kotlin/taehyeon/brothers/matchreal/infrastructure/common/LocalDateTimeHelperTest.kt
@@ -1,0 +1,47 @@
+package taehyeon.brothers.matchreal.infrastructure.common
+
+import io.kotest.matchers.equals.shouldBeEqual
+import io.kotest.matchers.equals.shouldNotBeEqual
+import java.time.LocalDateTime
+import java.time.Month
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+
+class LocalDateTimeHelperTest {
+
+    @AfterEach
+    fun tearDown() {
+        LocalDateTimeHelper.unfixCurrentTime()
+    }
+
+    @Test
+    fun fixCurrentTime() {
+        // given
+        // when
+        LocalDateTimeHelper.fixCurrentTime(LocalDateTime.of(2025, 2, 16, 11, 30, 55))
+
+        // then
+        val now = LocalDateTimeHelper.now()
+        now.month shouldBeEqual Month.FEBRUARY
+        now.dayOfMonth shouldBeEqual 16
+        now.hour shouldBeEqual 11
+        now.minute shouldBeEqual 30
+        now.second shouldBeEqual 55
+    }
+
+    @Test
+    fun unfixCurrentTime() {
+        // given
+        val notNow = LocalDateTime.of(2025, 2, 16, 11, 30, 55)
+        println("notNow: $notNow")
+        LocalDateTimeHelper.fixCurrentTime(notNow)
+
+        // when
+        LocalDateTimeHelper.unfixCurrentTime()
+
+        // then
+        val now = LocalDateTimeHelper.now()
+        println("now: $now")
+        now shouldNotBeEqual notNow
+    }
+}


### PR DESCRIPTION
## 개요
- 프로젝트 타임존을 Asia/Seoul 로 고정하였습니다.
- 시간 관련 커스텀세팅을 가능하도록 유틸성 클래스를 추가했습니다.
  - 이 덕분에, 데일리 업로드 시간 밸리데이션 통합테스트 작성이 용이해졌습니다. 

## 메인 리뷰어 지정 및 Due Date
- 메인 리뷰어 : @pjy1368  , Due Date : 2/22(토)

## 리뷰 시 참고 사항
- 

## TODO
- 시간 관련한 통합테스트 작성 시 LocalDateTimeHelper를 사용해주세요. 웬만하면 프로덕션 비즈니스 로직 작성 시에도 LocalDateTimeHelper.now() 를 사용해주세요. 테스트 코드 작성 시 의문사를 하지 않을 수 있으며, 관련 커스텀세팅을 우리가 할 수 있게 해줍니다.

## References
[1] https://umanking.github.io/2021/08/10/spring-boot-server-timezone/

## 체크리스트
- [x] PR 제목을 명령형으로 작성했습니다.
- [x] 리뷰 리퀘스트 전에 셀프 리뷰를 진행했습니다.
- [x] 변경사항에 대한 테스트코드를 추가했습니다. 또는, 테스트코드가 필요없는 이유가 있습니다.