### PR TITLE
feat: 피드 데일리 목록 조회 API 구현

### DIFF
--- a/src/main/kotlin/taehyeon/brothers/matchreal/application/daily/service/DailyService.kt
+++ b/src/main/kotlin/taehyeon/brothers/matchreal/application/daily/service/DailyService.kt
@@ -1,6 +1,8 @@
 package taehyeon.brothers.matchreal.application.daily.service
 
 import java.time.LocalTime
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -12,6 +14,8 @@ import taehyeon.brothers.matchreal.exception.business.NotFoundImageException
 import taehyeon.brothers.matchreal.exception.database.EntityNotFoundException
 import taehyeon.brothers.matchreal.infrastructure.common.LocalDateTimeHelper
 import taehyeon.brothers.matchreal.infrastructure.daily.repository.DailyRepository
+import taehyeon.brothers.matchreal.presentation.daily.dto.response.FeedDailyResponses
+import taehyeon.brothers.matchreal.presentation.daily.dto.response.FeedRawDailyResponse
 
 @Service
 @Transactional
@@ -43,5 +47,19 @@ class DailyService(
     fun findDailyById(dailyId: Long): Daily {
         return dailyRepository.findById(dailyId)
             .orElseThrow { EntityNotFoundException(message = "데일리가 존재하지 않습니다. dailyId: $dailyId") }
+    }
+
+    @Transactional(readOnly = true)
+    fun findAllDailies(currentPage: Int, contentSize: Int): FeedDailyResponses {
+        // TODO("현재는 최신순 정렬, 이후 GPT API 연동 및 태그 유사도 순 반영할 것")
+
+        val requestPage = PageRequest.of(currentPage, contentSize, Sort.by("createdAt").descending())
+        val dailiesWithPageInfo = dailyRepository.findAllBy(requestPage)
+            .map { FeedRawDailyResponse.from(it) }
+        return FeedDailyResponses.of(
+            dailiesWithPageInfo.number + 1, // 프론트는 1페이지부터, Spring data jpa 페이지네이션은 0페이지부터 시작.
+            dailiesWithPageInfo.totalPages,
+            dailiesWithPageInfo.content
+        )
     }
 }

--- a/src/main/kotlin/taehyeon/brothers/matchreal/infrastructure/daily/repository/DailyRepository.kt
+++ b/src/main/kotlin/taehyeon/brothers/matchreal/infrastructure/daily/repository/DailyRepository.kt
@@ -1,9 +1,13 @@
 package taehyeon.brothers.matchreal.infrastructure.daily.repository
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import taehyeon.brothers.matchreal.domain.daily.Daily
 
 @Repository
 interface DailyRepository : JpaRepository<Daily, Long> {
+
+    fun findAllBy(request: Pageable): Page<Daily>
 }

--- a/src/main/kotlin/taehyeon/brothers/matchreal/presentation/daily/controller/DailyController.kt
+++ b/src/main/kotlin/taehyeon/brothers/matchreal/presentation/daily/controller/DailyController.kt
@@ -24,6 +24,7 @@ import taehyeon.brothers.matchreal.presentation.daily.dto.request.TagAddRequest
 import taehyeon.brothers.matchreal.presentation.daily.dto.request.TagRemoveRequest
 import taehyeon.brothers.matchreal.presentation.daily.dto.response.AddTagResponse
 import taehyeon.brothers.matchreal.presentation.daily.dto.response.DailyUploadResponse
+import taehyeon.brothers.matchreal.presentation.daily.dto.response.FeedDailyResponses
 
 @RestController
 @RequestMapping("/api/v1/daily")
@@ -54,6 +55,16 @@ class DailyController(
             .contentType(MediaType.parseMediaType(daily.imageContentType))
             .contentLength(daily.imageContent.size.toLong())
             .body(InputStreamResource(ByteArrayResource(daily.imageContent)))
+    }
+
+    @GetMapping("/all")
+    fun getAll(
+        @RequiredLogin user: User,
+        @RequestParam page: Int,
+        @RequestParam size: Int
+    ): ResponseEntity<FeedDailyResponses> {
+        val response = dailyService.findAllDailies(page - 1, size)
+        return ResponseEntity.ok().body(response)
     }
 
     @PostMapping("/{dailyId}/tag")

--- a/src/main/kotlin/taehyeon/brothers/matchreal/presentation/daily/dto/response/DailyResponse.kt
+++ b/src/main/kotlin/taehyeon/brothers/matchreal/presentation/daily/dto/response/DailyResponse.kt
@@ -1,5 +1,66 @@
 package taehyeon.brothers.matchreal.presentation.daily.dto.response
 
+import org.springframework.core.io.ByteArrayResource
+import org.springframework.core.io.InputStreamResource
+import org.springframework.core.io.Resource
+import taehyeon.brothers.matchreal.domain.daily.Daily
+
 data class DailyUploadResponse(
     val dailyId: Long,
 )
+
+data class FeedDailyResponses(
+    val currentPage: Int,
+    val isEnd: Boolean,
+    val dailies: List<FeedDailyResponse>,
+) {
+    companion object {
+        fun of(currentPage: Int, totalPage: Int, feedRawDailyResponses: List<FeedRawDailyResponse>): FeedDailyResponses {
+            return FeedDailyResponses(
+                currentPage = currentPage,
+                isEnd = currentPage == totalPage,
+                dailies = feedRawDailyResponses.map { FeedDailyResponse.from(it) }
+            )
+        }
+    }
+}
+
+data class FeedDailyResponse(
+    val dailyId: Long,
+    val dailyImage: Resource,
+    val userId: Long,
+    val userNickname: String,
+) {
+    companion object {
+        fun from(feedRawDailyResponse: FeedRawDailyResponse): FeedDailyResponse {
+            return FeedDailyResponse(
+                dailyId = feedRawDailyResponse.dailyId,
+                dailyImage = InputStreamResource(ByteArrayResource(feedRawDailyResponse.imageContent)),
+                userId = feedRawDailyResponse.userId,
+                userNickname = feedRawDailyResponse.userNickname,
+            )
+        }
+    }
+}
+
+data class FeedRawDailyResponse(
+    val dailyId: Long,
+    val imageName: String,
+    val imageContentType: String,
+    val imageContent: ByteArray,
+    val userId: Long,
+    val userNickname: String,
+) {
+    companion object {
+        fun from(daily: Daily): FeedRawDailyResponse {
+            return FeedRawDailyResponse(
+                dailyId = daily.id,
+                imageName = daily.imageName,
+                imageContentType = daily.imageContentType,
+                imageContent = daily.imageContent,
+                userId = daily.user.id,
+                userNickname = daily.user.nickname,
+            )
+        }
+    }
+}

--- a/src/test/kotlin/taehyeon/brothers/matchreal/application/daily/service/DailyServiceTest.kt
+++ b/src/test/kotlin/taehyeon/brothers/matchreal/application/daily/service/DailyServiceTest.kt
@@ -122,11 +122,11 @@ class DailyServiceTest {
     @DisplayName("피드 데일리 목록 조회 - 최신순 정렬")
     fun findAllDailies() {
         // given
-        val daily1 = dailyRepository.save(DailyFixture.create(id = 1, user = testUser))
-        val daily2 = dailyRepository.save(DailyFixture.create(id = 2, user = testUser))
-        val daily3 = dailyRepository.save(DailyFixture.create(id = 3, user = testUser))
-        val daily4 = dailyRepository.save(DailyFixture.create(id = 4, user = testUser))
-        val daily5 = dailyRepository.save(DailyFixture.create(id = 5, user = testUser))
+        val daily1 = dailyRepository.save(DailyFixture.create(user = testUser))
+        val daily2 = dailyRepository.save(DailyFixture.create(user = testUser))
+        val daily3 = dailyRepository.save(DailyFixture.create(user = testUser))
+        val daily4 = dailyRepository.save(DailyFixture.create(user = testUser))
+        val daily5 = dailyRepository.save(DailyFixture.create(user = testUser))
 
         // when
         val result = dailyService.findAllDailies(1, 2)

--- a/src/test/kotlin/taehyeon/brothers/matchreal/application/daily/service/DailyServiceTest.kt
+++ b/src/test/kotlin/taehyeon/brothers/matchreal/application/daily/service/DailyServiceTest.kt
@@ -117,4 +117,24 @@ class DailyServiceTest {
         result.imageContentType shouldBe MediaType.IMAGE_JPEG.type
         result.imageName shouldBeEqual "클라이밍"
     }
+
+    @Test
+    @DisplayName("피드 데일리 목록 조회 - 최신순 정렬")
+    fun findAllDailies() {
+        // given
+        val daily1 = dailyRepository.save(DailyFixture.create(id = 1, user = testUser))
+        val daily2 = dailyRepository.save(DailyFixture.create(id = 2, user = testUser))
+        val daily3 = dailyRepository.save(DailyFixture.create(id = 3, user = testUser))
+        val daily4 = dailyRepository.save(DailyFixture.create(id = 4, user = testUser))
+        val daily5 = dailyRepository.save(DailyFixture.create(id = 5, user = testUser))
+
+        // when
+        val result = dailyService.findAllDailies(1, 2)
+
+        // then
+        result.currentPage shouldBeEqual 2
+        result.isEnd shouldBeEqual false
+        result.dailies[0].dailyId shouldBe daily3.id
+        result.dailies[1].dailyId shouldBe daily2.id
+    }
 }


### PR DESCRIPTION
## 개요
- 피드 데일리 목록 조회 api 를 구현했습니다. 페이지네이션이 적용돼있습니다.
- request, response는 [API 문서](https://www.notion.so/API-171243652c2880feb7e4d40d4e371a5d)를 참고해주세요.

## 메인 리뷰어 지정 및 Due Date
- 메인 리뷰어 : @pjy1368  , Due Date : 2025-3-22

## 리뷰 시 참고 사항
- 현재는 최신순 정렬만 했습니다.

## TODO
- 데일리 업로드 여부 api 추후 구현 필요

## References
[1] 내머리
[2] 제이온의 페이지네이션 구현하라는 협박

## 체크리스트
- [x] PR 제목을 명령형으로 작성했습니다.
- [x]  리뷰 리퀘스트 전에 셀프 리뷰를 진행했습니다.
- [x] 변경사항에 대한 테스트코드를 추가했습니다. 또는, 테스트코드가 필요없는 이유가 있습니다.