### PR TITLE
feat: 데일리 조회 시 userId, targetDate 로 필터링되도록 조건 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 	id("org.jetbrains.kotlin.plugin.allopen") version "1.9.25"
 	kotlin("plugin.jpa") version "1.9.25"
 	kotlin("plugin.noarg") version "1.9.25"
+	kotlin("kapt") version "1.9.25"
 }
 
 group = "taehyeon.brothers"
@@ -29,8 +30,14 @@ dependencies {
 
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.postgresql:postgresql:42.7.3")
+	// querydsl
 	implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")
-	annotationProcessor("com.querydsl:querydsl-apt:5.0.0:jakarta")
+	implementation("com.querydsl:querydsl-apt:5.0.0:jakarta")
+	implementation("jakarta.persistence:jakarta.persistence-api")
+	implementation("jakarta.annotation:jakarta.annotation-api")
+
+	kapt("com.querydsl:querydsl-apt:5.0.0:jakarta")
+	kapt("org.springframework.boot:spring-boot-configuration-processor")
 	annotationProcessor("jakarta.annotation:jakarta.annotation-api")
 	annotationProcessor("jakarta.persistence:jakarta.persistence-api")
 

--- a/src/main/kotlin/taehyeon/brothers/matchreal/application/daily/service/DailyService.kt
+++ b/src/main/kotlin/taehyeon/brothers/matchreal/application/daily/service/DailyService.kt
@@ -1,5 +1,6 @@
 package taehyeon.brothers.matchreal.application.daily.service
 
+import java.time.LocalDate
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
@@ -55,12 +56,15 @@ class DailyService(
     }
 
     @Transactional(readOnly = true)
-    fun findAllDailies(currentPage: Int, contentSize: Int): FeedDailyResponses {
-        // TODO("현재는 최신순 정렬, 이후 GPT API 연동 및 태그 유사도 순 반영할 것")
-
+    fun findAllDailies(userId: Long?, targetDate: LocalDate?, currentPage: Int, contentSize: Int): FeedDailyResponses {
         val requestPage = PageRequest.of(currentPage, contentSize, Sort.by("createdAt").descending())
-        val dailiesWithPageInfo = dailyRepository.findAllBy(requestPage)
-            .map { FeedRawDailyResponse.from(it) }
+        val dailiesWithPageInfo = dailyRepository.findAllBy(
+            userId,
+            targetDate?.atStartOfDay(),
+            targetDate?.atStartOfDay()?.plusDays(1)?.minusNanos(1),
+            requestPage
+        ).map { FeedRawDailyResponse.from(it) }
+
         return FeedDailyResponses.of(
             dailiesWithPageInfo.number + 1, // 프론트는 1페이지부터, Spring data jpa 페이지네이션은 0페이지부터 시작.
             dailiesWithPageInfo.totalPages,

--- a/src/main/kotlin/taehyeon/brothers/matchreal/infrastructure/config/QuerydslConfig.kt
+++ b/src/main/kotlin/taehyeon/brothers/matchreal/infrastructure/config/QuerydslConfig.kt
@@ -1,0 +1,17 @@
+package taehyeon.brothers.matchreal.infrastructure.config
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jakarta.persistence.EntityManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class QuerydslConfig(
+    private val entityManager: EntityManager
+) {
+
+    @Bean
+    fun jpaQueryFactory(): JPAQueryFactory {
+        return JPAQueryFactory(entityManager)
+    }
+}

--- a/src/main/kotlin/taehyeon/brothers/matchreal/infrastructure/config/QuerydslRepositorySupport.kt
+++ b/src/main/kotlin/taehyeon/brothers/matchreal/infrastructure/config/QuerydslRepositorySupport.kt
@@ -1,0 +1,14 @@
+package taehyeon.brothers.matchreal.infrastructure.config
+
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport
+
+class QuerydslRepositorySupport(
+    domainClass: Class<*>,
+) : QuerydslRepositorySupport(domainClass) {
+    @PersistenceContext
+    override fun setEntityManager(entityManager: EntityManager) {
+        super.setEntityManager(entityManager)
+    }
+}

--- a/src/main/kotlin/taehyeon/brothers/matchreal/infrastructure/daily/repository/DailyQuerydslRepository.kt
+++ b/src/main/kotlin/taehyeon/brothers/matchreal/infrastructure/daily/repository/DailyQuerydslRepository.kt
@@ -1,0 +1,18 @@
+package taehyeon.brothers.matchreal.infrastructure.daily.repository
+
+import java.time.LocalDateTime
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Repository
+import taehyeon.brothers.matchreal.domain.daily.Daily
+
+@Repository
+interface DailyQuerydslRepository {
+
+    fun findAllBy(
+        userId: Long?,
+        targetDateFrom: LocalDateTime?,
+        targetDateTo: LocalDateTime?,
+        pageable: Pageable
+    ): Page<Daily>
+}

--- a/src/main/kotlin/taehyeon/brothers/matchreal/infrastructure/daily/repository/DailyQuerydslRepositoryImpl.kt
+++ b/src/main/kotlin/taehyeon/brothers/matchreal/infrastructure/daily/repository/DailyQuerydslRepositoryImpl.kt
@@ -1,0 +1,45 @@
+package taehyeon.brothers.matchreal.infrastructure.daily.repository
+
+import com.querydsl.core.types.dsl.BooleanExpression
+import java.time.LocalDateTime
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Repository
+import taehyeon.brothers.matchreal.domain.daily.Daily
+import taehyeon.brothers.matchreal.domain.daily.QDaily.daily
+import taehyeon.brothers.matchreal.infrastructure.config.QuerydslRepositorySupport
+
+@Repository
+class DailyQuerydslRepositoryImpl :
+    QuerydslRepositorySupport(Daily::class.java),
+    DailyQuerydslRepository {
+    override fun findAllBy(
+        userId: Long?,
+        targetDateFrom: LocalDateTime?,
+        targetDateTo: LocalDateTime?,
+        pageable: Pageable
+    ): Page<Daily> {
+        val fetchResults = from(daily)
+            .where(
+                withValue(userId) { daily.user.id.eq(it) },
+                withValue(targetDateFrom) { daily.createdAt.goe(it) },
+                withValue(targetDateTo) { daily.createdAt.loe(it) }
+            )
+            .orderBy(daily.id.desc())
+            .offset(pageable.offset)
+            .limit(pageable.pageSize.toLong())
+            .fetchResults()
+
+        return PageImpl(fetchResults.results, pageable, fetchResults.total)
+    }
+}
+
+inline fun <T> withValue(
+    value: T?,
+    predicate: (T) -> BooleanExpression,
+): BooleanExpression? =
+    when (value) {
+        is Collection<*> -> if (value.isEmpty()) null else predicate(value)
+        else -> value?.let(predicate)
+    }

--- a/src/main/kotlin/taehyeon/brothers/matchreal/infrastructure/daily/repository/DailyRepository.kt
+++ b/src/main/kotlin/taehyeon/brothers/matchreal/infrastructure/daily/repository/DailyRepository.kt
@@ -1,13 +1,8 @@
 package taehyeon.brothers.matchreal.infrastructure.daily.repository
 
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import taehyeon.brothers.matchreal.domain.daily.Daily
 
 @Repository
-interface DailyRepository : JpaRepository<Daily, Long> {
-
-    fun findAllBy(request: Pageable): Page<Daily>
-}
+interface DailyRepository : JpaRepository<Daily, Long>, DailyQuerydslRepository

--- a/src/main/kotlin/taehyeon/brothers/matchreal/presentation/daily/controller/DailyController.kt
+++ b/src/main/kotlin/taehyeon/brothers/matchreal/presentation/daily/controller/DailyController.kt
@@ -1,6 +1,7 @@
 package taehyeon.brothers.matchreal.presentation.daily.controller
 
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import java.time.LocalDate
 import org.springframework.core.io.ByteArrayResource
 import org.springframework.core.io.InputStreamResource
 import org.springframework.core.io.Resource
@@ -61,10 +62,12 @@ class DailyController(
     @GetMapping("/all")
     fun getAll(
         @RequiredLogin user: User,
+        @RequestParam(required = false) userId: Long?,
+        @RequestParam(required = false) targetDate: LocalDate? = LocalDate.now(),
         @RequestParam page: Int,
         @RequestParam size: Int
     ): ResponseEntity<FeedDailyResponses> {
-        val response = dailyService.findAllDailies(page - 1, size)
+        val response = dailyService.findAllDailies(userId, targetDate, page - 1, size)
         return ResponseEntity.ok().body(response)
     }
 

--- a/src/test/kotlin/taehyeon/brothers/matchreal/application/daily/service/DailyServiceTest.kt
+++ b/src/test/kotlin/taehyeon/brothers/matchreal/application/daily/service/DailyServiceTest.kt
@@ -50,16 +50,24 @@ class DailyServiceTest {
     @Autowired
     private lateinit var userRepository: UserRepository
 
-    private lateinit var testUser: User
-    private lateinit var testRefreshToken: String
+    private lateinit var testUser1: User
+    private lateinit var testUser2: User
+    private lateinit var testRefreshToken1: String
+    private lateinit var testRefreshToken2: String
+    private val today: LocalDateTime = LocalDateTime.of(2025, 2, 16, 13, 30, 0)
 
     @BeforeEach
     fun setUp() {
-        LocalDateTimeHelper.fixCurrentTime(LocalDateTime.of(2025, 2, 16, 13, 30, 0))
-        val user = userRepository.save(UserFixture.create())
-        testRefreshToken = jwtTokenProvider.createRefreshToken(user)
-        user.updateRefreshToken(testRefreshToken)
-        testUser = userRepository.save(user)
+        LocalDateTimeHelper.fixCurrentTime(today)
+        val user1 = userRepository.save(UserFixture.create())
+        testRefreshToken1 = jwtTokenProvider.createRefreshToken(user1)
+        user1.updateRefreshToken(testRefreshToken1)
+        testUser1 = userRepository.save(user1)
+
+        val user2 = userRepository.save(UserFixture.create())
+        testRefreshToken2 = jwtTokenProvider.createRefreshToken(user2)
+        user2.updateRefreshToken(testRefreshToken2)
+        testUser2 = userRepository.save(user2)
     }
 
     @AfterEach
@@ -76,11 +84,11 @@ class DailyServiceTest {
         val dailyImage = DailyFixture.createDailyImage()
 
         // when
-        val daily = dailyService.uploadDaily(testUser, dailyImage)
+        val daily = dailyService.uploadDaily(testUser1, dailyImage)
 
         // then
         assertThat(daily).isNotNull()
-        daily.user shouldBe testUser
+        daily.user shouldBe testUser1
         daily.imageName shouldBe "클라이밍"
         daily.imageContentType shouldBe MediaType.IMAGE_JPEG.type
         daily.imageContent shouldBe "testImg".toByteArray()
@@ -96,7 +104,7 @@ class DailyServiceTest {
         val eventCaptor = ArgumentCaptor.forClass(DailyUploadedEvent::class.java)
 
         // when
-        val daily = testDailyService.uploadDaily(testUser, dailyImage)
+        val daily = testDailyService.uploadDaily(testUser1, dailyImage)
 
         // then
         verify(mockEventPublisher, times(1)).publishEvent(eventCaptor.capture())
@@ -111,7 +119,7 @@ class DailyServiceTest {
         val dailyImage = DailyFixture.createDailyImage()
 
         // when
-        val daily = dailyService.uploadDaily(testUser, dailyImage)
+        val daily = dailyService.uploadDaily(testUser1, dailyImage)
 
         // then
         assertThat(daily).isNotNull()
@@ -121,7 +129,7 @@ class DailyServiceTest {
     @DisplayName("데일리 및 태그 조회")
     fun findDailyById() {
         // given
-        val daily = dailyRepository.save(DailyFixture.create(user = testUser))
+        val daily = dailyRepository.save(DailyFixture.create(user = testUser1))
         val tag1 = tagRepository.save(TagFixture.create(daily = daily, tagName = "클라이밍"))
         val tag2 = tagRepository.save(TagFixture.create(daily = daily, tagName = "정적취미"))
         tagRepository.save(tag1)
@@ -142,7 +150,7 @@ class DailyServiceTest {
     @DisplayName("데일리 이미지 조회")
     fun findDailyImageById() {
         // given
-        val daily = dailyRepository.save(DailyFixture.create(user = testUser))
+        val daily = dailyRepository.save(DailyFixture.create(user = testUser1))
 
         // when
         val result = dailyService.findDailyImageById(dailyId = daily.id)
@@ -157,19 +165,28 @@ class DailyServiceTest {
     @DisplayName("피드 데일리 목록 조회 - 최신순 정렬")
     fun findAllDailies() {
         // given
-        val daily1 = dailyRepository.save(DailyFixture.create(user = testUser))
-        val daily2 = dailyRepository.save(DailyFixture.create(user = testUser))
-        val daily3 = dailyRepository.save(DailyFixture.create(user = testUser))
-        val daily4 = dailyRepository.save(DailyFixture.create(user = testUser))
-        val daily5 = dailyRepository.save(DailyFixture.create(user = testUser))
+        val daily1 =
+            dailyRepository.save(DailyFixture.createWithBaseTime(user = testUser1, createdAt = today.minusDays(1)))
+        val daily2 =
+            dailyRepository.save(DailyFixture.createWithBaseTime(user = testUser1, createdAt = today.minusDays(1)))
+
+        val daily3 = dailyRepository.save(DailyFixture.createWithBaseTime(user = testUser1, createdAt = today))
+        val daily4 = dailyRepository.save(DailyFixture.createWithBaseTime(user = testUser1, createdAt = today))
+        val daily5 = dailyRepository.save(DailyFixture.createWithBaseTime(user = testUser2, createdAt = today))
+
+        val daily6 =
+            dailyRepository.save(DailyFixture.createWithBaseTime(user = testUser1, createdAt = today.plusDays(1)))
+        val daily7 =
+            dailyRepository.save(DailyFixture.createWithBaseTime(user = testUser2, createdAt = today.plusDays(1)))
+
 
         // when
-        val result = dailyService.findAllDailies(1, 2)
+        val result = dailyService.findAllDailies(testUser1.id, today.toLocalDate(), 0, 2)
 
         // then
-        result.currentPage shouldBeEqual 2
-        result.isEnd shouldBeEqual false
-        result.dailies[0].dailyId shouldBe daily3.id
-        result.dailies[1].dailyId shouldBe daily2.id
+        result.currentPage shouldBeEqual 1
+        result.isEnd shouldBeEqual true
+        result.dailies[0].dailyId shouldBe daily4.id
+        result.dailies[1].dailyId shouldBe daily3.id
     }
 }

--- a/src/test/kotlin/taehyeon/brothers/matchreal/support/fixture/DailyFixture.kt
+++ b/src/test/kotlin/taehyeon/brothers/matchreal/support/fixture/DailyFixture.kt
@@ -1,5 +1,7 @@
 package taehyeon.brothers.matchreal.support.fixture
 
+import java.lang.reflect.Field
+import java.time.LocalDateTime
 import org.springframework.http.MediaType
 import org.springframework.mock.web.MockMultipartFile
 import taehyeon.brothers.matchreal.domain.daily.Daily
@@ -20,6 +22,25 @@ object DailyFixture {
         imageContentType = imageContentType,
         imageContent = imageContent,
     )
+
+    fun createWithBaseTime(
+        id: Long = 0L,
+        user: User,
+        imageName: String = "클라이밍",
+        imageContentType: String = MediaType.IMAGE_JPEG.type,
+        imageContent: ByteArray = "testImg".toByteArray(),
+        createdAt: LocalDateTime = LocalDateTime.now()
+    ): Daily {
+        val daily = Daily(
+            id = id,
+            user = user,
+            imageName = imageName,
+            imageContentType = imageContentType,
+            imageContent = imageContent,
+        )
+        setField<Daily>(daily, "createdAt", createdAt)
+        return daily
+    }
 
     fun createDailyImage(
         name: String = "test",
@@ -42,4 +63,26 @@ object DailyFixture {
         daily = daily,
         tagName = tagName
     )
+
+    fun <T> setField(entity: Any, fieldName: String, value: Any) {
+        var field: Field? = null
+        var clazz: Class<*>? = entity::class.java
+
+        // 상위 클래스까지 탐색
+        while (clazz != null) {
+            try {
+                field = clazz.getDeclaredField(fieldName)
+                break
+            } catch (e: NoSuchFieldException) {
+                clazz = clazz.superclass
+            }
+        }
+
+        if (field == null) {
+            throw NoSuchFieldException("Field '$fieldName' not found in class hierarchy")
+        }
+
+        field.isAccessible = true
+        field.set(entity, value)
+    }
 }


### PR DESCRIPTION
## 개요
- 데일리 전체 조회 시, 오늘날짜, 특정 유저 id로 필터링하여 조회하는 기능이 필요.
  - userId: Long?, targetDate: LocalDate? 추가
    - null인 경우 전체조회.  

## 메인 리뷰어 지정 및 Due Date
- 메인 리뷰어 : @pjy1368  , Due Date : ~5/2

## 리뷰 시 참고 사항
- 리뷰어에게 의견이 필요하거나, 리뷰어가 중점적으로 보면 좋을 부분을 나열해주세요.
    - (코멘트로 남겨주셔도 좋습니다)

## TODO
- 해당 PR이 머지 된 이후에 챙겨야할 부분을 나열해주세요.

## References
[1] 사용된 레퍼런스에 대한 링크를 남겨주세요.

## 체크리스트
- [ ] PR 제목을 명령형으로 작성했습니다.
- [ ] 리뷰 리퀘스트 전에 셀프 리뷰를 진행했습니다.
- [ ] 변경사항에 대한 테스트코드를 추가했습니다. 또는, 테스트코드가 필요없는 이유가 있습니다.